### PR TITLE
fix: use folders in a consistent way in `.dockerignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/templates/.dockerignore.ejs
+++ b/templates/.dockerignore.ejs
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/express/.dockerignore
+++ b/test/express/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/fastify/.dockerignore
+++ b/test/fastify/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/gatsby/.dockerignore
+++ b/test/gatsby/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/nest/.dockerignore
+++ b/test/nest/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/next-npm/.dockerignore
+++ b/test/next-npm/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/next-pnpm/.dockerignore
+++ b/test/next-pnpm/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/next-yarn/.dockerignore
+++ b/test/next-yarn/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/nuxt/.dockerignore
+++ b/test/nuxt/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile

--- a/test/remix-indie/.dockerignore
+++ b/test/remix-indie/.dockerignore
@@ -1,5 +1,5 @@
-.git
-node_modules
+/.git
+/node_modules
 .dockerignore
 .env
 Dockerfile


### PR DESCRIPTION
This way, it's more clear what exactly is a folder and what is a file