### PR TITLE
try testing each framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
+  # run eslint and compare outputs with expected results
   test:
     runs-on: ubuntu-latest
     steps:
@@ -12,20 +13,8 @@ jobs:
       - run: npm ci
       - run: npm run eslint
       - run: npm test
-  test-docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: "npm"
-      - run: npm ci
-      - run: npm run eslint
-      - run: npm run test:with_docker
 
-  # test each framework
+  # test each framework can actually build
   test-frameworks:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,21 @@ jobs:
       - run: npm ci
       - run: npm run eslint
       - run: npm run test:with_docker
+
+  # test each framework
+  test-frameworks:
+    runs-on: ubuntu-latest
+    matrix:
+      framework:
+        - express
+        - fastify
+        - gatsby
+        - nest
+        - next-yarn
+        - nuxt
+        - remix-indie
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - run: docker buildx build . --build-arg NODE_VERSION=18
+        working-directory: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
       - run: docker buildx build . --build-arg NODE_VERSION=18
-        working-directory: ${{ matrix.framework }}
+        working-directory: test/${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,16 @@ jobs:
   # test each framework
   test-frameworks:
     runs-on: ubuntu-latest
-    matrix:
-      framework:
-        - express
-        - fastify
-        - gatsby
-        - nest
-        - next-yarn
-        - nuxt
-        - remix-indie
+    strategy:
+      matrix:
+        framework:
+          - express
+          - fastify
+          - gatsby
+          - nest
+          - next-yarn
+          - nuxt
+          - remix-indie
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ To assis with this process, outputs of tests can be captured automatically.  Thi
 ```
 npm run test:capture
 ```
+
+Additionally, each the outputs in each test directory can be directly tested to ensure that they can be successfully built by running docker buildx directory passing in the necessary build arguments.  For example:
+
+```
+docker buildx build . --build-arg NODE_VERSION=18
+```

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "eslint": "eslint .",
     "eslint:fix": "eslint --fix .",
     "test": "mocha",
-    "test:capture": "TEST_CAPTURE=1 mocha",
-    "test:with_docker": "DOCKER_BUILD=1 mocha --timeout 300000"
+    "test:capture": "TEST_CAPTURE=1 mocha"
   },
   "author": "Sam Ruby",
   "license": "MIT",

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,6 @@ import fs from 'node:fs'
 import { expect } from 'chai'
 
 import { GDF } from '../gdf.js'
-import { execSync } from 'node:child_process'
 
 const entries = fs.readdirSync('test', { withFileTypes: true })
 

--- a/test/test.js
+++ b/test/test.js
@@ -53,22 +53,6 @@ describe('dockerfile-node-test', function () {
         expect(expectedResults).to.equal(actualResults)
       })
 
-      if (process.env.DOCKER_BUILD) {
-        it('should build docker image successfully', async function () {
-          const dockerImageName = `dockerfile-node-test-${entry.name}`
-          await new GDF().run(workdir)
-
-          // build the docker image
-          try {
-            const results = execSync(`docker buildx build -t ${dockerImageName} .`, { cwd: workdir })
-
-            expect(results.toString()).to.not.match(/\bError:.*\b/)
-          } catch (err) {
-            expect('the test to run without an exception').to.equal('but it did not') // force test to fail, i don't know a better way to do this
-          }
-        })
-      }
-
       if (pj.includes('prisma')) {
         it('should produce a docker-entrypoint', async function () {
           await new GDF().run(workdir)


### PR DESCRIPTION
Try testing each framework directly.  The intent is to enable the selection of which directories are tested using docker build, and to run the tests in parallel.