### PR TITLE
fix(epic-stack): remove `ENCRYPTION_SECRET` from required secrets

### DIFF
--- a/fly.js
+++ b/fly.js
@@ -167,7 +167,6 @@ GDF.extend(class extends GDF {
 
     const required = [
       'SESSION_SECRET',
-      'ENCRYPTION_SECRET',
       'INTERNAL_COMMAND_TOKEN'
     ]
 


### PR DESCRIPTION
See https://github.com/epicweb-dev/epic-stack/blob/main/docs/decisions/014-totp.md#consequences