### PR TITLE
fix: check all required secrets

### DIFF
--- a/fly.js
+++ b/fly.js
@@ -174,7 +174,7 @@ GDF.extend(class extends GDF {
     ]
 
     for (const name of required) {
-      if (secrets.includes(name)) return
+      if (secrets.includes(name)) continue
       if (name !== 'SESSION_SECRET' && !this.epicStack) continue
 
       const value = crypto.randomBytes(32).toString('hex')
@@ -206,7 +206,7 @@ GDF.extend(class extends GDF {
     ]
 
     for (const name of required) {
-      if (secrets.includes(name)) return
+      if (secrets.includes(name)) continue
 
       const value = crypto.randomBytes(32).toString('hex')
 


### PR DESCRIPTION
Without this change, the `flyRemixSecrets` would be stopped completely, so it wouldn't check for `INTERNAL_COMMAND_TOKEN` if `SESSION_SECRET` was already present