### PR TITLE
Add `.meteor/local` to dockerignore template

### DIFF
--- a/templates/.dockerignore.ejs
+++ b/templates/.dockerignore.ejs
@@ -10,3 +10,7 @@ fly.toml
 /build
 /public/build
 <% } -%>
+
+<% if (meteor) { -%>
+/.meteor/local
+<% } -%>


### PR DESCRIPTION
Otherwise we send huge, unneeded local context to the docker daemon