### PR TITLE
Default to not using --link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options are saved between runs into `package.json`. To invert a boolean options,
 * `--legacy-peer-deps` - [ignore peer dependencies](https://docs.npmjs.com/cli/v7/using-npm/config#legacy-peer-deps).
 * `--litefs` - configure and enable [litefs](https://fly.io/docs/litefs/).
 * `--nginxRoot=DIR` - serve static files from given directory via [nginx](https://www.nginx.com/).
-* `--no-link` - don't add [--link](https://docs.docker.com/engine/reference/builder/#copy---link) to COPY statements.  Some tools (like at the moment, [buildah](https://www.redhat.com/en/topics/containers/what-is-buildah)) don't yet support this feature.
+* `--link` - Add [--link](https://docs.docker.com/engine/reference/builder/#copy---link) to COPY statements.  Some tools, including [buildah](https://www.redhat.com/en/topics/containers/what-is-buildah)) or [Buildkit](https://docs.docker.com/build/buildkit/) don't properly support this feature.
 * `--port=n` - expose port (default may vary based on framework, but otherwise is `3000`)
 * `--swap=n` - allocate swap space.  See [falloc options](https://man7.org/linux/man-pages/man1/fallocate.1.html#OPTIONS) for suffixes
 * `--windows` - make Dockerfile work for Windows users that may have set `git config --global core.autocrlf true`.

--- a/gdf.js
+++ b/gdf.js
@@ -22,7 +22,7 @@ export const defaults = {
   distroless: false,
   ignoreScripts: false,
   legacyPeerDeps: false,
-  link: true,
+  link: false,
   litefs: false,
   nginxRoot: '',
   port: 0,

--- a/test/base/alpine/Dockerfile
+++ b/test/base/alpine/Dockerfile
@@ -21,11 +21,11 @@ RUN apk update && \
     apk add build-base gyp pkgconfig python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/build-secret/Dockerfile
+++ b/test/base/build-secret/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN --mount=type=secret,id=DATABASE_URL \

--- a/test/base/build/Dockerfile
+++ b/test/base/build/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run tsc

--- a/test/base/bun/Dockerfile
+++ b/test/base/bun/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential pkg-config python-is-python3
 
 # Install node modules
-COPY --link bun.lockb package.json ./
+COPY bun.lockb package.json ./
 RUN bun install --ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/cache-bun/Dockerfile
+++ b/test/base/cache-bun/Dockerfile
@@ -23,12 +23,12 @@ RUN --mount=type=cache,id=cache,target=/var/cache/apt \
     apt-get install --no-install-recommends -y build-essential pkg-config python-is-python3
 
 # Install node modules
-COPY --link bun.lockb package.json ./
+COPY bun.lockb package.json ./
 RUN --mount=type=cache,id=bun,target=/root/.bun \
     bun install
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN bun run build

--- a/test/base/cache-npm/Dockerfile
+++ b/test/base/cache-npm/Dockerfile
@@ -23,12 +23,12 @@ RUN --mount=type=cache,id=cache,target=/var/cache/apt \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN --mount=type=cache,id=npm,target=/app/.npm \
     npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/base/cache-pnpm/Dockerfile
+++ b/test/base/cache-pnpm/Dockerfile
@@ -30,12 +30,12 @@ RUN --mount=type=cache,id=cache,target=/var/cache/apt \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile --prod=false
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN pnpm run build

--- a/test/base/cache-yarn/Dockerfile
+++ b/test/base/cache-yarn/Dockerfile
@@ -25,12 +25,12 @@ RUN --mount=type=cache,id=cache,target=/var/cache/apt \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json yarn.lock ./
+COPY package.json yarn.lock ./
 RUN --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn/ \
     yarn install --frozen-lockfile --production=false
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN yarn run build

--- a/test/base/cmd-entrypoint/Dockerfile
+++ b/test/base/cmd-entrypoint/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/defer-build/Dockerfile
+++ b/test/base/defer-build/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp openssl pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Generate Prisma Client
-COPY --link prisma .
+COPY prisma .
 RUN npx prisma generate
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/dev/Dockerfile
+++ b/test/base/dev/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/base/distroless/Dockerfile
+++ b/test/base/distroless/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/envargs/Dockerfile
+++ b/test/base/envargs/Dockerfile
@@ -30,11 +30,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/base/fluent-ffmpeg/Dockerfile
+++ b/test/base/fluent-ffmpeg/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json ./
+COPY package.json ./
 RUN npm install
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/git/Dockerfile
+++ b/test/base/git/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential git node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json ./
+COPY package.json ./
 RUN npm install
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/ignore-scripts/Dockerfile
+++ b/test/base/ignore-scripts/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --ignore-scripts
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/instructions/Dockerfile
+++ b/test/base/instructions/Dockerfile
@@ -23,11 +23,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/base/legacy-peer-deps/Dockerfile
+++ b/test/base/legacy-peer-deps/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --legacy-peer-deps
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/litefs/Dockerfile
+++ b/test/base/litefs/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/nginx/Dockerfile
+++ b/test/base/nginx/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/packages/Dockerfile
+++ b/test/base/packages/Dockerfile
@@ -26,11 +26,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential libicu-dev node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/base/port/Dockerfile
+++ b/test/base/port/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/puppeteer/Dockerfile
+++ b/test/base/puppeteer/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json ./
+COPY package.json ./
 RUN npm install
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/swap/Dockerfile
+++ b/test/base/swap/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/version/Dockerfile
+++ b/test/base/version/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/base/windows/Dockerfile
+++ b/test/base/windows/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp openssl pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Generate Prisma Client
-COPY --link prisma .
+COPY prisma .
 RUN npx prisma generate
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/fly/sqlite3/Dockerfile
+++ b/test/fly/sqlite3/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/frameworks/adonisjs/Dockerfile
+++ b/test/frameworks/adonisjs/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json ./
+COPY package.json ./
 RUN npm install --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/astro-ssr/Dockerfile
+++ b/test/frameworks/astro-ssr/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/astro-static/Dockerfile
+++ b/test/frameworks/astro-static/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/express/Dockerfile
+++ b/test/frameworks/express/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/frameworks/fastify/Dockerfile
+++ b/test/frameworks/fastify/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 
 # Final stage for app image

--- a/test/frameworks/gatsby/Dockerfile
+++ b/test/frameworks/gatsby/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --legacy-peer-deps
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/meteor/Dockerfile
+++ b/test/frameworks/meteor/Dockerfile
@@ -28,12 +28,12 @@ ENV METEOR_ALLOW_SUPERUSER=1
 # Extract the Meteor release version and install Meteor
 RUN RELEASE=$(awk -F'@' '{print $2}' /home/meteor/.meteor/release) && curl https://install.meteor.com/\?release\=$RELEASE | sh
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 RUN meteor npm install
 # Copy application code
-COPY --link . .
+COPY . .
 RUN meteor build --server-only --directory bundle
 
 # https://github.com/meteor/meteor/issues/12932

--- a/test/frameworks/nest/Dockerfile
+++ b/test/frameworks/nest/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/next-npm/Dockerfile
+++ b/test/frameworks/next-npm/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/next-pnpm/Dockerfile
+++ b/test/frameworks/next-pnpm/Dockerfile
@@ -25,11 +25,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN pnpm run build

--- a/test/frameworks/next-standalone/Dockerfile
+++ b/test/frameworks/next-standalone/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/next-yarn/Dockerfile
+++ b/test/frameworks/next-yarn/Dockerfile
@@ -23,11 +23,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json yarn.lock ./
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN yarn run build

--- a/test/frameworks/next-yarn3/Dockerfile
+++ b/test/frameworks/next-yarn3/Dockerfile
@@ -26,11 +26,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json yarn.lock ./
+COPY package.json yarn.lock ./
 RUN yarn install --immutable
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN yarn run build

--- a/test/frameworks/nuxt/Dockerfile
+++ b/test/frameworks/nuxt/Dockerfile
@@ -23,11 +23,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json yarn.lock ./
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production=false
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN yarn run build

--- a/test/frameworks/remix-blues/Dockerfile
+++ b/test/frameworks/remix-blues/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp openssl pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Generate Prisma Client
-COPY --link prisma .
+COPY prisma .
 RUN npx prisma generate
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/remix-epic/Dockerfile
+++ b/test/frameworks/remix-epic/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp openssl pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Generate Prisma Client
-COPY --link prisma .
+COPY prisma .
 RUN npx prisma generate
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/remix-indie/Dockerfile
+++ b/test/frameworks/remix-indie/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp openssl pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Generate Prisma Client
-COPY --link prisma .
+COPY prisma .
 RUN npx prisma generate
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build

--- a/test/frameworks/remix-pnpm/Dockerfile
+++ b/test/frameworks/remix-pnpm/Dockerfile
@@ -25,11 +25,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod=false
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN pnpm run build

--- a/test/frameworks/svelte-bun/Dockerfile
+++ b/test/frameworks/svelte-bun/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential pkg-config python-is-python3
 
 # Install node modules
-COPY --link bun.lockb package.json ./
+COPY bun.lockb package.json ./
 RUN bun install
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN bun --bun run build

--- a/test/frameworks/vite/Dockerfile
+++ b/test/frameworks/vite/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --include=dev
 
 # Copy application code
-COPY --link . .
+COPY . .
 
 # Build application
 RUN npm run build


### PR DESCRIPTION
Fly.io Depot builders use Buildkit, which currently has an upstream bug causing caches to fill up quickly when using `--link`. Generally, Depot recommends against using this option, so we default to `false`.